### PR TITLE
docs: translated the sidebar and benchmark to `cn`

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -7,7 +7,7 @@
     "message": "编译能力",
     "description": "Farm 的各项编译能力文档"
   },
-  "sidebar.tutorialSidebar.category.Benchmark": {
+  "sidebar.tutorialSidebar.category.Benchmarks": {
     "message": "基准测试",
     "description": "Farm 的各项编译能力以及其他框架基准测试的对比"
   },
@@ -18,6 +18,18 @@
   "sidebar.tutorialSidebar.category.Tutorial": {
     "message": "教程",
     "description": "Farm 的教程文档"
+  },
+  "sidebar.tutorialSidebar.category.Advanced": {
+    "message": "高级用法",
+    "description": "Farm 的进阶用法介绍"
+  },
+  "sidebar.tutorialSidebar.category.Frameworks": {
+    "message": "框架模版",
+    "description": "Farm 的框架支持模版"
+  },
+  "sidebar.tutorialSidebar.category.Migration": {
+    "message": "迁移指南",
+    "description": "从其他构建工具迁移到Farm 的指南"
   },
   "sidebar.pluginSidebar.category.Writing Plugins": {
     "message": "编写插件",

--- a/i18n/zh/docusaurus-plugin-content-docs/current/benchmark.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/benchmark.md
@@ -1,10 +1,10 @@
 # Benchmarks
 
-Using Turbopack's bench cases (1000 React components), see https://turbo.build/pack/docs/benchmarks.
+使用 Turbopack 的基准案例（1000 个 React 组件），请参阅 https://turbo.build/pack/docs/benchmarks.
 
-> Test Repo：https://github.com/farm-fe/performance-compare
+> 测试仓库：https://github.com/farm-fe/performance-compare
 >
-> Test Machine（Linux Mint 21.1 Cinnamon， 11th Gen Intel© Core™ i5-11400 @ 2.60GHz × 6， 15.5 GiB）
+> 测试机器：(Linux Mint 21.1 Cinnamon， 11th Gen Intel© Core™ i5-11400 @ 2.60GHz × 6， 15.5 GiB)
 
 ![xx](/img/benchmark.png)
 


### PR DESCRIPTION
我尝试将`Benchmarks`修改到和侧边栏一样的字符但是仍然不能在dev模式下被正确翻译。
![ed0b8e0184308109d993886c62e8f38](https://github.com/farm-fe/farm-fe.github.io/assets/81673017/43c95b96-de54-42cd-a51e-fe6d9edc55b5)
