### PR TITLE
chore: fix typo in static assets docs

### DIFF
--- a/docs/features/static.md
+++ b/docs/features/static.md
@@ -49,7 +49,7 @@ import { defineConfig } from '@farmfe/core';
 export default defineConfig({
   compilation: {
     output: {
-      assetFilename: 'assets/[resourceName].[hash].[ext]', // [] is a placeholder, Farm currently only these three kind of placeholders
+      assetsFilename: 'assets/[resourceName].[hash].[ext]', // [] is a placeholder, Farm currently only these three kind of placeholders
     },
     assets: {
       include: ['txt'] // extra static asset extension


### PR DESCRIPTION
<img width="836" alt="image" src="https://github.com/user-attachments/assets/1eea56a4-3c07-4945-82b2-4cf0d32c93d6">
