### PR TITLE
refactor: fix the SSR/CSR mismatch

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@8
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm i --no-frozen-lockfile --unsafe-perm --ignore-scripts
       - name: Test build website
         run: pnpm build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -210,6 +210,7 @@ const config = {
       },
     }),
   plugins: [
+    customPostCssPlugin,
     "docusaurus-plugin-sass",
     async function TailwindCSSPlugin(context, options) {
       return {
@@ -224,5 +225,17 @@ const config = {
     },
   ],
 };
+
+/** @return {import('@docusaurus/types').Plugin} */
+function customPostCssPlugin() {
+  return {
+    name: "custom-postcss",
+    configurePostCss(options) {
+      // Append new PostCSS plugins here.
+      options.plugins.push(require("postcss-preset-env")); // allow newest CSS syntax
+      return options;
+    }
+  };
+}
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "documate:upload": "documate upload"
   },
   "dependencies": {
+    "postcss-preset-env": "^10.0.3",
     "@crowdin/cli": "3",
     "@crowdin/crowdin-api-client": "^1.23.4",
     "@docusaurus/core": "3.4.0",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import Link from "@docusaurus/Link";
-import { useColorMode } from "@docusaurus/theme-common";
+// import useBaseUrl from '@docusaurus/useBaseUrl';
+import ThemedImage from '@theme/ThemedImage';
 import Translate from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
@@ -100,8 +101,6 @@ function HomepageHeader() {
 
 
 const HomeBaseContent = () => {
-  const { colorMode } = useColorMode();
-
   const mainContent = React.useMemo(() => {
     return (
       <main className="mb-20 my-10 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8max-w-6xl">
@@ -112,21 +111,16 @@ const HomeBaseContent = () => {
     );
   }, []);
 
-  if (colorMode === "dark") {
     return (
       <>
-        <StarrySky />
+        <ThemedImage sources={{
+            light: <StarrySky />,
+            dark: <AuroraBackground />,
+          }}
+        />
         {mainContent}
       </>
     );
-  } else {
-    return (
-      <>
-        <AuroraBackground />
-        {mainContent}
-      </>
-    );
-  }
 };
 
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import Link from "@docusaurus/Link";
-import { useColorMode } from "@docusaurus/theme-common";
+import { useColorMode, ColorModeProvider } from "@docusaurus/theme-common";
 import Translate from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,17 @@
 import Link from "@docusaurus/Link";
-import { useColorMode, ColorModeProvider } from "@docusaurus/theme-common";
-import React from "react";
-import clsx from "clsx";
+import { useColorMode } from "@docusaurus/theme-common";
+import Translate from "@docusaurus/Translate";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
+import clsx from "clsx";
+import React from "react";
 import Benchmark from "../components/Benchmark";
-import StarrySky from "../components/StarrySky";
-import styles from "./index.module.css";
-import Translate from "@docusaurus/Translate";
 import AnimatedGradientStarWithGithub from "../components/MagicUi/animated-shiny-text";
 import BlurFade from "../components/MagicUi/blur-fade";
 import BentoGridCard from "../components/MagicUi/card";
+import StarrySky from "../components/StarrySky";
 import { AuroraBackground } from "../components/ui/aurora-back";
-import BrowserOnly from "@docusaurus/BrowserOnly";
+import styles from "./index.module.css";
 
 function HomepageHeader() {
   return (
@@ -99,35 +98,37 @@ function HomepageHeader() {
   );
 }
 
-const MainContent = () => (
-  <main className="mb-20 my-10 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8max-w-6xl">
-    <AnimatedGradientStarWithGithub />
-    <HomepageHeader />
-    <BentoGridCard />
-  </main>
-);
 
-const AuroraBackContent = () => (
-  <AuroraBackground>
-    <MainContent />
-  </AuroraBackground>
-);
-
-const skyContent = () => (
-  <>
-    <StarrySky />
-    <MainContent />
-  </>
-);
-
-const HomePage = () => {
+const HomeBaseContent = () => {
   const { colorMode } = useColorMode();
-  if (colorMode === 'dark') {
-    return skyContent();
+
+  const mainContent = React.useMemo(() => {
+    return (
+      <main className="mb-20 my-10 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8max-w-6xl">
+        <AnimatedGradientStarWithGithub />
+        <HomepageHeader />
+        <BentoGridCard />
+      </main>
+    );
+  }, []);
+
+  if (colorMode === "dark") {
+    return (
+      <>
+        <StarrySky />
+        {mainContent}
+      </>
+    );
   } else {
-    return AuroraBackContent();
+    return (
+      <>
+        <AuroraBackground />
+        {mainContent}
+      </>
+    );
   }
 };
+
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
@@ -137,9 +138,7 @@ export default function Home() {
       title={`${siteConfig.title} Documentation`}
       description="Description will go into a meta tag in <head />"
     >
-      <ColorModeProvider>
-        <HomePage />
-      </ColorModeProvider>
+      <HomeBaseContent />
     </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -138,7 +138,9 @@ export default function Home() {
       title={`${siteConfig.title} Documentation`}
       description="Description will go into a meta tag in <head />"
     >
-      <HomeBaseContent />
+      <ColorModeProvider>
+        <HomeBaseContent />
+      </ColorModeProvider>
     </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,6 @@ import clsx from "clsx";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import Benchmark from "../components/Benchmark";
-import { useColorMode } from '@docusaurus/theme-common';
 import StarrySky from "../components/StarrySky";
 import styles from "./index.module.css";
 import Translate from "@docusaurus/Translate";
@@ -25,7 +24,6 @@ function HomepageHeader() {
       )}
     >
       <div className="container w-full flex flex-col my-1 px-2">
-
         <BlurFade delay={0.25} inView>
           <div className="font-extrabold text-3xl sm:text-6xl lg:text-6xl text-left mb-6 flex flex-col gap-2">
             <div>
@@ -62,7 +60,10 @@ function HomepageHeader() {
                 <Translate>Farm </Translate>
               </span>
               <span className="font-sans">
-                <Translate>is a Rust-Based Web Building Engine to Facilitate Your Web Program and JavaScript Library</Translate>
+                <Translate>
+                  is a Rust-Based Web Building Engine to Facilitate Your Web
+                  Program and JavaScript Library
+                </Translate>
               </span>
             </div>
           </div>
@@ -110,14 +111,14 @@ const AuroraBackContent = () => (
   <AuroraBackground>
     <MainContent />
   </AuroraBackground>
-)
+);
 
 const skyContent = () => (
   <>
     <StarrySky />
     <MainContent />
   </>
-)
+);
 
 const HomePage = () => {
   const { colorMode } = useColorMode();
@@ -126,7 +127,7 @@ const HomePage = () => {
   } else {
     return AuroraBackContent();
   }
-}
+};
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
@@ -139,6 +140,6 @@ export default function Home() {
       <ColorModeProvider>
         <HomePage />
       </ColorModeProvider>
-    </Layout >
+    </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,19 @@
 import Link from "@docusaurus/Link";
 import { useColorMode, ColorModeProvider } from "@docusaurus/theme-common";
-import Translate from "@docusaurus/Translate";
+import React from "react";
+import clsx from "clsx";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
-import clsx from "clsx";
-import React from "react";
 import Benchmark from "../components/Benchmark";
+import { useColorMode } from '@docusaurus/theme-common';
+import StarrySky from "../components/StarrySky";
+import styles from "./index.module.css";
+import Translate from "@docusaurus/Translate";
 import AnimatedGradientStarWithGithub from "../components/MagicUi/animated-shiny-text";
 import BlurFade from "../components/MagicUi/blur-fade";
 import BentoGridCard from "../components/MagicUi/card";
-import StarrySky from "../components/StarrySky";
 import { AuroraBackground } from "../components/ui/aurora-back";
-import styles from "./index.module.css";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 function HomepageHeader() {
   return (
@@ -23,6 +25,7 @@ function HomepageHeader() {
       )}
     >
       <div className="container w-full flex flex-col my-1 px-2">
+
         <BlurFade delay={0.25} inView>
           <div className="font-extrabold text-3xl sm:text-6xl lg:text-6xl text-left mb-6 flex flex-col gap-2">
             <div>
@@ -59,10 +62,7 @@ function HomepageHeader() {
                 <Translate>Farm </Translate>
               </span>
               <span className="font-sans">
-                <Translate>
-                  is a Rust-Based Web Building Engine to Facilitate Your Web
-                  Program and JavaScript Library
-                </Translate>
+                <Translate>is a Rust-Based Web Building Engine to Facilitate Your Web Program and JavaScript Library</Translate>
               </span>
             </div>
           </div>
@@ -98,37 +98,35 @@ function HomepageHeader() {
   );
 }
 
+const MainContent = () => (
+  <main className="mb-20 my-10 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8max-w-6xl">
+    <AnimatedGradientStarWithGithub />
+    <HomepageHeader />
+    <BentoGridCard />
+  </main>
+);
 
-const HomeBaseContent = () => {
+const AuroraBackContent = () => (
+  <AuroraBackground>
+    <MainContent />
+  </AuroraBackground>
+)
+
+const skyContent = () => (
+  <>
+    <StarrySky />
+    <MainContent />
+  </>
+)
+
+const HomePage = () => {
   const { colorMode } = useColorMode();
-
-  const mainContent = React.useMemo(() => {
-    return (
-      <main className="mb-20 my-10 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8max-w-6xl">
-        <AnimatedGradientStarWithGithub />
-        <HomepageHeader />
-        <BentoGridCard />
-      </main>
-    );
-  }, []);
-
-  if (colorMode === "dark") {
-    return (
-      <>
-        <StarrySky />
-        {mainContent}
-      </>
-    );
+  if (colorMode === 'dark') {
+    return skyContent();
   } else {
-    return (
-      <>
-        <AuroraBackground />
-        {mainContent}
-      </>
-    );
+    return AuroraBackContent();
   }
-};
-
+}
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
@@ -139,8 +137,8 @@ export default function Home() {
       description="Description will go into a meta tag in <head />"
     >
       <ColorModeProvider>
-        <HomeBaseContent />
+        <HomePage />
       </ColorModeProvider>
-    </Layout>
+    </Layout >
   );
 }


### PR DESCRIPTION
### What happened?

Due to the CSS not being written in a format supported by Webpack[^1], I imported `postcss-preset-env`(https://github.com/farm-fe/farm-fe.github.io/pull/146/commits/a10ec67eb6b983aaeeacb1a79f400229b75aff78) and created the `customPostCssPlugin` function(https://github.com/farm-fe/farm-fe.github.io/pull/146/commits/091a16fcceb464453c99c50ce807090ed5b523ef) (_the code is provided below_) to enable runtime plugins, achieving the goal of using preset environment CSS. This has clearly been effective.

```ts
function customPostCssPlugin() {
  return {
    name: "custom-postcss",
    configurePostCss(options) {
      // Append new PostCSS plugins here
      options.plugins.push(require("postcss-preset-env")); // allow newest CSS syntax
      return options;
    }
  };
}
```

----

*The Changes*

> [!IMPORTANT]
**There is one remaining warning, similar to the previous ones.**
**This final error is still due to the CSS format, but it cannot be detected by the customPostCssPlugin.**

| ![image](https://github.com/user-attachments/assets/bc278231-4583-4d6a-a212-c0a67b11abad) | *__before__* |
| ----------------------------------------------------------------------------------------------------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/f217da80-0415-47bc-a93d-cdc09fd0bf1f) | *__after__*|

So you can continue to make modifications from this perspective to try to get the compilation build workflow to pass. Since it's already quite late (USTC +8), I currently don't have the ability to further investigate any suspicious CSS syntax.

This is the everything about WA.

---

Literally, I noticed the error about `useColorMode()` in prod mode. **Values derived from useColorMode() can be stale when rendering in prod mode**, so we have to avoid to use `import { useColorMode } from '@docusaurus/theme-common';` and this is likely a react hydration problem.

```ts
const getInitialColorMode = (defaultMode: ColorMode | undefined): ColorMode =>
  ExecutionEnvironment.canUseDOM
    ? coerceToColorMode(document.documentElement.getAttribute('data-theme'))
    : coerceToColorMode(defaultMode);

  const [colorMode, setColorModeState] = useState(
    getInitialColorMode(defaultMode),
  );
```

Asfaik, react 18 introduces a [onRecoverableError](https://reactjs.org/docs/react-dom-client.html#createroot) callback which usually notice you of hydration mismatches.

In this case we can't technically init react state with the correct value, but instead should always init it to the default color mode, and then trigger a new re-render to fix it after hydration.

```ts
const [colorMode, setColorModeState] = useState(defaultMode);

useLayoutEffect(() => {
  coerceToColorMode(document.documentElement.getAttribute('data-theme'))
},[])
```

This should fix the SSR/CSR mismatch, but this is a bit annoying unfortunately, as it will mean some components will render first with the wrong colorMode and then eventually re-render with the right one.

[^1]: https://github.com/webpack/webpack/issues/14893
