### PR TITLE
fix: fix Configuring Alias And Externals example error

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/tutorials/2-start.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/tutorials/2-start.md
@@ -266,13 +266,11 @@ export default defineConfig({
   compilation: {
     resolve: {
       alias: {
-        '@/': path.join(process.cwd(), 'src')
+        "@/": path.join(process.cwd(), "src"),
       },
-      externals: [
-        'node:fs'
-      ]
-    }
-  }
+    },
+    externals: ["node:fs"],
+  },
   // ...
 });
 ```


### PR DESCRIPTION
the Chinese doc need fix `Configuring Alias And Externals` example error

the origin version is https://github.com/farm-fe/farm-fe.github.io/blob/5392a4a4b661355bd0abb8a99974152e4b1eb81d/docs/tutorials/2-start.md?plain=1#L306
![image](https://github.com/user-attachments/assets/21d99528-db75-4d44-80c8-4dff35713ce3)

the Chinese version is error，externals position is error
![image](https://github.com/user-attachments/assets/4ab304c2-d941-4bf3-9ece-2484f109c2b6)
