### PR TITLE
fix(nestjs): link to the right example

### DIFF
--- a/docs/frameworks/nestjs.mdx
+++ b/docs/frameworks/nestjs.mdx
@@ -23,4 +23,4 @@ After downloading the template, run pnpm dev to start the nestjs project
 
 Start enjoying the development experience of millisecond builds
 
-For more example details: [React Example](https://github.com/farm-fe/farm/tree/main/examples/react)
+For more example details: [NestJs Example](https://github.com/farm-fe/farm/tree/main/examples/nestjs)


### PR DESCRIPTION
Hi there 👋🏼 

It looks like the example at the end of NestJS is a copy-paste of the link from the React page.

Cheers and thanks for the good work.