### PR TITLE
Auto import 文档

### DIFF
--- a/docs/plugins/official-plugins/auto-import.mdx
+++ b/docs/plugins/official-plugins/auto-import.mdx
@@ -1,0 +1,191 @@
+import CodeBlock from "@theme/CodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# @farmfe/plugin-auto-import
+
+Automatically import methods from third-party libraries on demand.
+
+## Installation
+
+<Tabs>
+  <TabItem value="npm" label="npm">
+    <CodeBlock>npm install @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+    <CodeBlock>yarn add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    <CodeBlock>pnpm add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+  <TabItem value="bun" label="bun">
+    <CodeBlock>bun add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+</Tabs>
+
+## Usage
+
+`@farmfe/plugin-auto-import`is a Rust plugin. You just need to configure its package name in the `plugins` field of the `farm.config.(t|j|mj)s` file.
+
+```ts {4}
+import { UserConfig } from "@farmfe/core";
+import AutoImport from "@farmfe/plugin-auto-import";
+
+const config: UserConfig = {
+  plugins: [
+    AutoImport({
+      /** Options go here */
+    }),
+  ],
+};
+```
+
+## Features
+
+- 💚 Supports React and React-Router out of the box.
+- 🏝 Tree-shaking: Only registers the components you actually use, reducing bundle size.
+- 🪐 Folder names as namespaces.
+- 🦾 Full TypeScript support.
+
+## Usage
+
+Similar to the `unplugin-auto-import plugin`, it automatically imports components so that you no longer need to manually `import`.
+
+It will automatically convert this:
+
+```tsx
+export function Main() {
+  const [ops, setOps] = useState([]);
+
+  return (
+    <div>
+      {ops.map((k) => (
+        <span key={`k`}>{k}</span>
+      ))}
+    </div>
+  );
+}
+```
+
+Into this:
+
+
+```tsx
+import { useState } from "react";
+export function Main() {
+  const [ops, setOps] = useState([]);
+
+  return (
+    <div>
+      {ops.map((k) => (
+        <span key={`k`}>{k}</span>
+      ))}
+    </div>
+  );
+}
+```
+
+:::warning 
+
+1.Components are not supported yet: Currently, only automatic imports for function APIs are supported; components are not supported.
+
+2.Hot reload limitation: If you modify the plugin configuration in farm.config.(t|j|mj|cj)s, please restart the farm server.
+:::
+
+## TypeScript
+
+Enable `TypeScript` support for automatically imported components.
+
+```ts
+AutoImport({
+  dts: true, // Enabled by default if `typescript` is installed.
+});
+```
+
+After setting up, an `auto-import.d.ts` file will be automatically generated and type definitions will be updated. You can choose whether to commit it to `Git`.
+
+> **Ensure that you also add `auto-import.d.ts` to the include section of your `tsconfig.json`.**
+
+:::tip
+
+For `JavaScript` projects, if you want complete function type hints when using this plugin, you need to configure the `jsconfig.json` file
+
+:::
+
+```js
+{
+  "compilerOptions": {
+    "checkJs": false,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "typeRoots": ["auto-import.d.ts"]
+  }
+}
+```
+
+## Third-Party Library Support
+```ts
+{
+  "react", // Default configuration
+  "react-router", // Default configuration
+  {
+    from: "lodash-es", // Automatically import functions from the lodash-es module
+    imports: [
+      "debounce",
+      "throttle",
+      "isEqual",
+      "isEmpty",
+      "isNil",
+      "isFunction",
+      "isObject",
+      "isArray",
+      "isString",
+      "isNumber",
+      "isBoolean",
+      "isDate",
+      "isRegExp",
+      "isSymbol",
+      "isMap",
+      "isSet",
+      "isWeakMap",
+      "isWeakSet",
+    ],
+  },
+}
+```
+
+## Configuration
+
+The following shows the default configuration:
+
+```ts
+{
+
+   // Generate a global declaration `auto-import.d.ts`.
+  // Also accepts custom file paths.
+  // Default: `true` if the `typescript` package is installed.
+  dts: true,
+
+  // Filters for conversion targets (components to insert automatic imports).
+  // Note: This is not about including/excluding registered components - use `Regex` for that.
+  include: ["src/components"], // Included directories
+  exclude: ["node_modules"], // Excluded directories
+
+  // Directories to scan automatically.
+  dirs: ['src/hooks', 'src/components'],
+
+  // Modules to automatically import.
+  presets: [
+    "react", // Default configuration
+    "react-router", // Default configuration
+  ]
+}
+
+
+```
+
+The current default`presets`: `["pinia", "react", "react-router", "vue", "vue-router"]`,  For more details, refer to the [source repository](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/src/presets/mod.rs)。
+
+If you need to view the complete type definition, refer to the[source configuration](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/options.d.ts)

--- a/docs/plugins/official-plugins/overview.md
+++ b/docs/plugins/official-plugins/overview.md
@@ -15,6 +15,7 @@ Refer to [Using Plugins](/docs/using-plugins) for how to use plugins in Farm.
 * **[`@farmfe/plugin-yaml`](./yaml)**：A Farm plugin which Converts YAML files to ES6 modules.
 * **[`@farmfe/plugin-virtual`](./virtual)**：A rust plugin for farm to easily use virtual module.
 * **[`@farmfe/plugin-react-components`](./react-components)**：On-demand components auto importing for React.
+* **[`@farmfe/plugin-auto-import`](./auto-import)**: On-demand auto importing for npm packages.
 
 ## Js Plugins
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
@@ -1,0 +1,148 @@
+import CodeBlock from "@theme/CodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# @farmfe/plugin-auto-import
+
+按需自动导入第三方库的方法
+
+## 安装
+
+
+<Tabs>
+  <TabItem value="npm" label="npm">
+    <CodeBlock>npm install @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+    <CodeBlock>yarn add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    <CodeBlock>pnpm add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+    <TabItem value="bun" label="bun">
+    <CodeBlock>bun add @farmfe/plugin-auto-import</CodeBlock>
+  </TabItem>
+</Tabs>
+
+## 使用
+
+`@farmfe/plugin-auto-import` 是一个Rust插件,只需要在 `farm.config.(t|j|mj)s` 的的 `plugins` 字段中配置其包名即可。
+
+```ts {4}
+import { UserConfig } from '@farmfe/core';
+import AutoImport from '@farmfe/plugin-auto-import'
+
+const config: UserConfig = {
+  plugins: [
+    AutoImport({
+       /** 选项在此 */
+    })
+  ]
+}
+```
+## 功能
+
+- 💚 支持React和React-Router开箱即用
+- 🏝 树摇（Tree-shaking），只注册你使用的组件。
+- 🪐 文件夹名称作为命名空间。
+- 🦾 完整的TypeScript支持。
+
+## 使用
+
+和 `unplugin-auto-import`插件一样的用法,他讲自动引入组件 不再需要 `import`
+
+他会自动将这个
+
+```tsx
+export function Main() {
+  const [ops, setOps] = useState([])
+
+  return (<div>
+    {
+      ops.map(k => (<span key={`k`}>{k}</span>))
+    }
+  </div>)
+}
+```
+
+转化成这个
+
+```tsx
+import {useState} from "react"
+export function Main() {
+  const [ops, setOps] = useState([])
+
+  return (<div>
+    {
+      ops.map(k => (<span key={`k`}>{k}</span>))
+    }
+  </div>)
+}
+
+```
+
+:::warning
+1.该插件暂时不支持 `组件`，只支持 `function api`。对于第三方的`npm`包来说也是一样的
+
+2.该插件暂时不支持配置的热更新,如果在 `farm.cofnig.(t|j|mj|cj)s`中变更请重启 `farm server`
+:::
+
+## TypeScript
+
+为自动导入的组件获得TypeScript支持。
+
+```ts
+AutoImport({
+  dts: true, // 如果安装了`typescript`默认启用
+})
+```
+
+完成设置后，将自动生成一个`auto-import.d.ts`文件，并自动更新类型定义。你可以选择是否将其提交到git。
+
+> **确保你也将`auto-import.d.ts`添加到`tsconfig.json`的`include`中。**
+
+:::tip
+在 `JavaScript` 项目中，如果是用来该插件并且想获取完整的函数类型提示 需要配置 `jsconfig.json`文件
+
+
+:::
+```js
+
+```
+
+## 使用第三方库
+
+
+
+## 配置
+以下显示了配置的默认值
+```ts
+{
+
+  // 生成全局声明的`auto-import.d.ts`，
+  // 也接受自定义文件名的路径
+  // 默认：如果安装了typescript包则为`true`
+  dts: true,
+
+  // 转换目标（要插入自动导入的组件）的过滤器
+  // 注意，这不是关于包含/排除注册组件 - 使用`Regex`来做那个
+  include: ["src/components"],
+  exclude: ["node_modules"],
+  // 配置项
+  dirs: ['src/hooks', 'src/components'],
+  // 需要自动导入的模块
+  presets: [
+    "react", // 默认配置
+    "react-router", // 默认配置
+    {
+      from: "lodash-es", // lodash-es npm自动引入示例
+      imports: ["debounce", "throttle", "isEqual", "isEmpty", "isNil", "isFunction", "isObject", "isArray", "isString", "isNumber", "isBoolean", "isDate", "isRegExp", "isSymbol", "isMap", "isSet", "isWeakMap", "isWeakSet"],
+    }
+  ]
+}
+
+
+```
+当前默认配置有`presets`: `["pinia", "react", "react-router", "vue", "vue-router"]`, 也可以[点击](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/src/presets/mod.rs)。
+
+想要查看 auto-import类型定义 请[点击](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/options.d.ts)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
@@ -80,11 +80,10 @@ export function Main() {
 }
 
 ```
-
 :::warning
 
 1.暂不支持组件：目前仅支持函数 API 的自动导入，组件暂不受支持。
-
+2.热更新限制：如果在 `farm.config.(t|j|mj|cj)s` 中修改了插件配置，请重启 `farm server`。
 2.热更新限制：如果在 `farm.config.(t|j|mj|cj)s` 中修改了插件配置，请重启 `farm server
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
@@ -43,13 +43,13 @@ const config: UserConfig = {
 ## 功能
 
 - 💚 支持React和React-Router开箱即用
-- 🏝 树摇（Tree-shaking），只注册你使用的组件。
+- 🏝 树摇（Tree-shaking），仅注册实际使用的组件，减少打包体积。
 - 🪐 文件夹名称作为命名空间。
 - 🦾 完整的TypeScript支持。
 
 ## 使用
 
-和 `unplugin-auto-import`插件一样的用法,他讲自动引入组件 不再需要 `import`
+和 `unplugin-auto-import`插件一样的用法, 自动引入组件 不再需要 `import`
 
 他会自动将这个
 
@@ -82,9 +82,10 @@ export function Main() {
 ```
 
 :::warning
-1.该插件暂时不支持 `组件`，只支持 `function api`。对于第三方的`npm`包来说也是一样的
 
-2.该插件暂时不支持配置的热更新,如果在 `farm.cofnig.(t|j|mj|cj)s`中变更请重启 `farm server`
+1.暂不支持组件：目前仅支持函数 API 的自动导入，组件暂不受支持。
+
+2.热更新限制：如果在 `farm.config.(t|j|mj|cj)s` 中修改了插件配置，请重启 `farm server
 :::
 
 ## TypeScript
@@ -103,15 +104,53 @@ AutoImport({
 
 :::tip
 在 `JavaScript` 项目中，如果是用来该插件并且想获取完整的函数类型提示 需要配置 `jsconfig.json`文件
-
-
 :::
-```js
 
+对于 JavaScript 项目，如果需要完整的函数类型提示，可以配置 jsconfig.json 文件：
+
+```json
+{
+  "compilerOptions": {、
+    "checkJs": false,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "typeRoots": ["auto-import.d.ts"]
+  },
+}
 ```
 
-## 使用第三方库
-
+## 第三方库支持
+```ts
+{
+  "react", // 默认配置
+  "react-router", // 默认配置
+  {
+    from: "lodash-es", // 自动导入 lodash-es 模块中的函数
+    imports: [
+      "debounce",
+      "throttle",
+      "isEqual",
+      "isEmpty",
+      "isNil",
+      "isFunction",
+      "isObject",
+      "isArray",
+      "isString",
+      "isNumber",
+      "isBoolean",
+      "isDate",
+      "isRegExp",
+      "isSymbol",
+      "isMap",
+      "isSet",
+      "isWeakMap",
+      "isWeakSet",
+    ],
+  },
+}
+```
 
 
 ## 配置
@@ -126,23 +165,19 @@ AutoImport({
 
   // 转换目标（要插入自动导入的组件）的过滤器
   // 注意，这不是关于包含/排除注册组件 - 使用`Regex`来做那个
-  include: ["src/components"],
-  exclude: ["node_modules"],
-  // 配置项
+  include: ["src/components"],// 包含的目录
+  exclude: ["node_modules"], // 排除的目录
+   // 自动扫描的目录
   dirs: ['src/hooks', 'src/components'],
   // 需要自动导入的模块
   presets: [
     "react", // 默认配置
     "react-router", // 默认配置
-    {
-      from: "lodash-es", // lodash-es npm自动引入示例
-      imports: ["debounce", "throttle", "isEqual", "isEmpty", "isNil", "isFunction", "isObject", "isArray", "isString", "isNumber", "isBoolean", "isDate", "isRegExp", "isSymbol", "isMap", "isSet", "isWeakMap", "isWeakSet"],
-    }
   ]
 }
 
 
 ```
-当前默认配置有`presets`: `["pinia", "react", "react-router", "vue", "vue-router"]`, 也可以[点击](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/src/presets/mod.rs)。
+当前默认配置有`presets`: `["pinia", "react", "react-router", "vue", "vue-router"]`, 更多详情可参考[源码仓库](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/src/presets/mod.rs)
 
-想要查看 auto-import类型定义 请[点击](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/options.d.ts)
+如需查看完整类型定义，请参考[源码配置](https://github.com/farm-fe/plugins/blob/main/rust-plugins/auto-import/options.d.ts)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/auto-import.mdx
@@ -108,15 +108,6 @@ AutoImport({
 
 对于 JavaScript 项目，如果需要完整的函数类型提示，可以配置 jsconfig.json 文件：
 
-```json
-{
-  "compilerOptions": {、
-    "checkJs": false,
-    "baseUrl": "./src",
-    "paths": {
-      "@/*": ["*"]
-    },
-    "typeRoots": ["auto-import.d.ts"]
   },
 }
 ```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/overview.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/plugins/official-plugins/overview.md
@@ -15,6 +15,7 @@ Farm官方提供了很多有用的插件，包括Rust插件和JS插件。 Rust �
 * **[`@farmfe/plugin-yaml`](./yaml)**：一个Farm插件，用于将YAML文件转换为ES6模块。
 * **[`@farmfe/plugin-virtual`](./virtual)**：一个方便在farm中使用虚拟模块的rust插件。
 * **[`@farmfe/plugin-react-components`](./react-components)**：用于React的按需组件自动导入。
+* **[`@farmfe/plugin-auto-import`](./auto-import)**: 一个Farm插件，用于自动引入npm package以及本地函数的插件。
 
 ## Js 插件
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -144,6 +144,7 @@ const sidebars = {
             "plugins/official-plugins/yaml",
             "plugins/official-plugins/virtual",
             "plugins/official-plugins/react-components",
+            "plugins/official-plugins/auto-import",
           ],
         },
         {


### PR DESCRIPTION
新增了 @farmfe/plugin-auto-import的文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guides for the new auto-import plugin, covering installation via multiple package managers, configuration, usage examples, and feature highlights including React and TypeScript support.
  - Expanded the plugin overview listings and updated the navigation menus in both English and Chinese to help users easily locate and understand the auto-import functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->