### PR TITLE
feat: 添加对 Farm@1.3+ 版本 Rust 插件的使用说明

### DIFF
--- a/docs/using-plugins.md
+++ b/docs/using-plugins.md
@@ -70,6 +70,25 @@ Currently Farm supports 2 rust plugins officially:
 * **`@farmfe/plugin-react`**: Farm rust plugin for react jsx compilation and react-refresh injection.
 * **`@farmfe/plugin-sass`**: Farm rust plugin for scss files compilation, uses `sass-embedded` internally.
 
+
+If you are using version `Farm@1.3+` or above; you can use it in the same way as the `js-plugin` pluin. For example, `@farmfe/plugin-react`
+
+
+```ts title="farm.config.ts"
+import reactPlugin from "@farmfe/plugin-react";
+
+export default defineConfig({
+  plugins: [
+     // Use the function approach to call Rust plugins
+    reactPlugin({
+      // Settings
+    })
+  ],
+});
+```
+
+
+
 :::tip
 To learn more about rust plugins, see [Rust Plugins](/docs/plugins/official-plugins/overview#rust-plugins)
 :::

--- a/docs/using-plugins.md
+++ b/docs/using-plugins.md
@@ -71,7 +71,7 @@ Currently Farm supports 2 rust plugins officially:
 * **`@farmfe/plugin-sass`**: Farm rust plugin for scss files compilation, uses `sass-embedded` internally.
 
 
-If you are using version `Farm@1.3+` or above; you can use it in the same way as the `js-plugin` pluin. For example, `@farmfe/plugin-react`
+If you are using version `Farm@1.3+` or above; you can use it in the same way as the `js-plugin` plugin. For example, `@farmfe/plugin-react`
 
 
 ```ts title="farm.config.ts"

--- a/i18n/zh/docusaurus-plugin-content-docs/current/using-plugins.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/using-plugins.md
@@ -67,6 +67,22 @@ export default defineConfig({
 * **`@farmfe/plugin-react`**：Farm rust 插件，用于 React jsx 编译和 React-refresh 注入。
 * **`@farmfe/plugin-sass`**：用于 scss 文件编译的 Farm rust 插件，内部使用 `sass-embedded`。
 
+如果你使用的是 `Farm@1.3+`版本以上：可以像 `js-plugin`插件使用的方式那样驶入。比如说 `@farmfe/plugin-react`
+
+```ts title="farm.config.ts"
+import reactPlugin from "@farmfe/plugin-react";
+
+export default defineConfig({
+  plugins: [
+    //使用 函数的方式调用 Rust 插件
+    reactPlugin({
+      // 设置
+    })
+  ],
+});
+```
+
+
 :::tip
 要了解有关 rust 插件的更多信息，请参阅 [Rust 插件](/docs/plugins/official-plugins/overview#rust-插件)
 :::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/using-plugins.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/using-plugins.md
@@ -67,7 +67,7 @@ export default defineConfig({
 * **`@farmfe/plugin-react`**：Farm rust 插件，用于 React jsx 编译和 React-refresh 注入。
 * **`@farmfe/plugin-sass`**：用于 scss 文件编译的 Farm rust 插件，内部使用 `sass-embedded`。
 
-如果你使用的是 `Farm@1.3+`版本以上：可以像 `js-plugin`插件使用的方式那样驶入。比如说 `@farmfe/plugin-react`
+如果你使用的是 `Farm@1.3+`版本以上：可以像 `js-plugin`插件一样使用它。比如说 `@farmfe/plugin-react`
 
 ```ts title="farm.config.ts"
 import reactPlugin from "@farmfe/plugin-react";


### PR DESCRIPTION
新增 `rust plugin` 在 `farm@1.3`的说明文档

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include a new usage pattern for Rust plugins starting from version 1.3, allowing them to be imported and used as functions similar to JS plugins.
  - Added examples demonstrating the new function call syntax for Rust plugins in both English and Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->